### PR TITLE
Add timer system to remove expired invites from cache

### DIFF
--- a/invites.py
+++ b/invites.py
@@ -31,6 +31,10 @@ from discord.ext import commands, tasks
 
 # poll period in minutes for the
 # update_invite_expiry task
+# if you want to change this
+# to use seconds you need
+# to update the kwarg in the
+# decorator too
 POLL_PERIOD = 25
 
 

--- a/invites.py
+++ b/invites.py
@@ -23,19 +23,22 @@ SOFTWARE.
 """
 import asyncio
 import datetime
-import json
 import time
 from typing import Dict, Optional
 
 import discord
 from discord.ext import commands, tasks
 
+# poll period in minutes for the
+# update_invite_expiry task
+POLL_PERIOD = 25
+
 
 class Invites(commands.Cog):
-    def __init__(self, bot):
+    def __init__(self, bot: commands.Bot):
         self.bot = bot
         self._invites_ready = asyncio.Event()
-        self._iter_complete = asyncio.Event()
+        self._list_filled = asyncio.Event()
 
         self.bot.invites = {}
         self.bot.get_invite = self.get_invite
@@ -44,49 +47,105 @@ class Invites(commands.Cog):
         self.bot.loop.create_task(self.__ainit__())
 
     async def __ainit__(self):
+        # wait until the bots internal cache is ready
         await self.bot.wait_until_ready()
 
         for guild in self.bot.guilds:
-            self.bot.invites[guild.id] = e = await self.fetch_invites(guild) or {}
+            self.bot.invites[guild.id] = await self.fetch_invites(guild) or {}
         self.update_invite_expiry.start()
         self.delete_expired.start()
 
     @tasks.loop()
     async def delete_expired(self):
         invites = self.bot.expiring_invites
-        expiry_time = min(invites.keys())
-        inv = invites[expiry_time]
-        sleep_time = expiry_time - (int(time.time()) - self.bot.last_update)
-        self.bot.shortest_invite = expiry_time
-        await asyncio.sleep(sleep_time)
-        self.delete_invite(inv)
+        if not invites:
+            # cancel the task until the list gets filled once again
+            # we have to access a protected member because we are
+            # using ext.tasks
+            def restart_when_list_filled(fut):
+                self.delete_expired._task.remove_done_callback(restart_when_list_filled)
+
+                async def wait():
+                    await self._list_filled.wait()
+                    self.delete_expired.start()
+
+                self.bot.loop.create_task(wait())
+
+            # dont want to try and cancel the task if we
+            # are already cancelling so we check that
+            # the task is not already being cancelled
+            if self.delete_expired._can_be_cancelled():
+                self.delete_expired._task.add_done_callback(restart_when_list_filled)
+                self.delete_expired.cancel()
+        # if the list is populated
+        else:
+            expiry_time = min(invites.keys())
+            inv = invites[expiry_time]
+            sleep_time = expiry_time - (int(time.time()) - self.bot.last_update)
+            self.bot.shortest_invite = expiry_time
+            await asyncio.sleep(sleep_time)
+            # delete invite from cache
+            self.delete_invite(inv)
+            # delete invite from expiring invite list
+            self.bot.expiring_invites.pop(expiry_time, None)
 
     @delete_expired.before_loop
     async def wait_for_list(self):
         await self.wait_for_invites()
 
-    @tasks.loop(minutes=25)
+    @tasks.loop(minutes=POLL_PERIOD)
     async def update_invite_expiry(self):
+        # check to see if it is set
+        # because on the first iteration
+        # it will not be
+        if self._list_filled.is_set():
+            self._list_filled.clear()
+        # flatten all the invites in the cache into one single list
         flattened = [invite for inner in self.bot.invites.values() for invite in inner.values()]
+        # get current posix time
         current = time.time()
         self.bot.expiring_invites = {
-            inv.max_age - int(current - inv.created_at.replace(tzinfo=datetime.timezone.utc).timestamp()): inv for inv
-            in flattened if inv.max_age != 0}
+            inv.max_age - int(current - inv.created_at.replace(tzinfo=datetime.timezone.utc).timestamp()): inv
+            for inv in flattened if inv.max_age != 0}
+
+        exists = True
+
+        # update self.bot.shortest_invite
+        # so we can compare it with invites
+        # that were just created
+        try:  # self.bot.shortest_invite might not exist
+            self.bot.shortest_invite = self.bot.shortest_invite - int(time.time() - self.bot.last_update)
+        except AttributeError:
+            exists = False
 
         if self.update_invite_expiry.current_loop == 0:
             # this needs to be updated before
             # setting self._invites_ready
             self.bot.last_update = int(current)
             self._invites_ready.set()
-        elif self.bot.shortest_invite - int(time.time() - self.bot.last_update) > min(self.bot.expiring_invites.keys()):
+        # we need to check that expiring_invites
+        # is truthy otherwise this conditional will
+        # raise an error because we passed an
+        # empty sequence to min()
+        elif exists and self.bot.expiring_invites and self.bot.shortest_invite > min(self.bot.expiring_invites.keys()):
             # this conditional needs to run before we
             # update self._last_update
             self.delete_expired.restart()
             self.bot.last_update = int(current)
         else:
+            # the last update needs to be updated regardless or
+            # it will cause updates getting deleted from the cache
+            # too early because the expiring_invites list will be
+            # updated with new times but delete_expired will think
+            # that the last update was ages ago and will deduct a huge
+            # amount of seconds from the expiry time to form the sleep_time
             self.bot.last_update = int(current)
+        # set the event so if the delete_expired
+        # task is cancelled it will start again
+        self._list_filled.set()
 
-    def delete_invite(self, invite: discord.Invite):
+
+    def delete_invite(self, invite: discord.Invite) -> None:
         entry_found = self.get_invites(invite.guild.id)
         entry_found.pop(invite.code, None)
 
@@ -101,7 +160,7 @@ class Invites(commands.Cog):
     def get_invites(self, guild_id: int) -> Optional[Dict[str, discord.Invite]]:
         return self.bot.invites.get(guild_id, None)
 
-    async def wait_for_invites(self):
+    async def wait_for_invites(self) -> None:
         if not self._invites_ready.is_set():
             await self._invites_ready.wait()
 
@@ -113,7 +172,7 @@ class Invites(commands.Cog):
         else:
             return {invite.code: invite for invite in invites}
 
-    async def _schedule_deletion(self, guild: discord.Guild):
+    async def _schedule_deletion(self, guild: discord.Guild) -> None:
         seconds_passed = 0
 
         while seconds_passed < 300:
@@ -127,7 +186,7 @@ class Invites(commands.Cog):
             self.bot.invites.pop(guild.id, None)
 
     @commands.Cog.listener()
-    async def on_invite_create(self, invite: discord.Invite):
+    async def on_invite_create(self, invite: discord.Invite) -> None:
         print(f"created invite {invite} in {invite.guild}")
         cached = self.bot.invites.get(invite.guild.id, None)
 
@@ -135,11 +194,11 @@ class Invites(commands.Cog):
             cached[invite.code] = invite
 
     @commands.Cog.listener()
-    async def on_invite_delete(self, invite: discord.Invite):
+    async def on_invite_delete(self, invite: discord.Invite) -> None:
         self.delete_invite(invite)
 
     @commands.Cog.listener()
-    async def on_guild_channel_delete(self, channel: discord.abc.GuildChannel):
+    async def on_guild_channel_delete(self, channel: discord.abc.GuildChannel) -> None:
         invites = self.bot.invites.get(channel.guild.id)
 
         if invites:
@@ -149,22 +208,22 @@ class Invites(commands.Cog):
                     invites.pop(invite.code)
 
     @commands.Cog.listener()
-    async def on_guild_join(self, guild: discord.Guild):
+    async def on_guild_join(self, guild: discord.Guild) -> None:
         invites = await self.fetch_invites(guild) or {}
         self.bot.invites[guild.id] = invites
 
     @commands.Cog.listener()
-    async def on_guild_available(self, guild: discord.Guild):
+    async def on_guild_available(self, guild: discord.Guild) -> None:
         # reload all invites in case they changed during
         # the time that the guilds were unavailable
         self.bot.invites[guild.id] = await self.fetch_invites(guild) or {}
 
     @commands.Cog.listener()
-    async def on_guild_remove(self, guild: discord.Guild):
+    async def on_guild_remove(self, guild: discord.Guild) -> None:
         self.bot.create_task(self._schedule_deletion(guild))
 
     @commands.Cog.listener()
-    async def on_member_join(self, member: discord.Member):
+    async def on_member_join(self, member: discord.Member) -> None:
         invites = await self.fetch_invites(member.guild)
 
         if invites:
@@ -182,18 +241,46 @@ class Invites(commands.Cog):
                     self.bot.dispatch("invite_update", member, new)
                     break
 
-    @commands.command(name='invitestats')
-    async def invite_stats(self, ctx):
+    # if you want to use this command you
+    # might want to make a error handler
+    # to handle commands.NoPrivateMessage
+    @commands.guild_only()
+    @commands.command()
+    async def invitestats(self, ctx):
+        """Displays the top 10 most used invites in the guild."""
         # PEP8 + same code, more readability
-        cache = {}
+        invites = self.bot.invites.get(ctx.guild.id, None)
 
-        for guild, invites in self.bot.invites.items():
-            cached_invites = cache[guild] = {}
+        # falsey check for None or {}
+        if not invites:
+            # if there is no invites send this information
+            # in an embed and return
+            embed = discord.Embed(colour=discord.Colour.red(), description='No invites found...')
+            await ctx.send(embed=embed)
+            return
 
-            for invite in invites.values():
-                cached_invites[invite.code] = invite.uses
-        await ctx.send(json.dumps(cache))
+        # if you got here there are invites in the cache
+        embed = discord.Embed(colour=discord.Colour.green(), title='Most used invites')
+        # sort the invites by the amount of uses
+        # by default this would make it in increasing
+        # order so we pass True to the reverse kwarg
+        invites = sorted(invites.values(), key=lambda i: i.uses, reverse=True)
+        # if there are 10 or more invites in the cache we will
+        # display 10 invites, otherwise display the amount
+        # of invites
+        amount = 10 if len(invites) >= 10 else len(invites)
+        # list comp on the sorted invites and then
+        # join it into one string with str.join
+        description = '\n'.join([f'{i + 1}. {invites[i].code} - {invites[i].uses}' for i in range(amount)])
+        embed.description = description
+        # if there are more than 10 invites
+        # add a footer saying how many more
+        # invites there are
+        if amount > 10:
+            embed.set_footer(text=f'There are {len(invites) - 10} more invites in this guild.')
+        await ctx.send(embed=embed)
 
 
-def setup(bot):
+
+def setup(bot: commands.Bot):
     bot.add_cog(Invites(bot))

--- a/invites.py
+++ b/invites.py
@@ -176,8 +176,8 @@ class Invites(commands.Cog):
                     self.bot.dispatch("invite_update", member, new)
                     break
 
-    @commands.command(name='invitestats')
-    async def invite_stats(self, ctx):
+    @commands.command()
+    async def invitestats(self, ctx):
         # PEP8 + same code, more readability
         cache = {}
 


### PR DESCRIPTION
AHHH ITS FINALLY HERE AFTER DAYS OF TESTING AND DEBUGGING 

This pull request should hopefully fix #1.

### Changes

- Added a timer system
  
  The reason I made this pull request was in hopes to fix #1. After looking through the method that was used to check which invite was incremented I came up with a theory that somehow the cache and the newly fetched invite lists had different lengths. After some testing this theory was proven and I discovered that when invites expire (run out of time), `on_invite_delete` isn't called. This is probably due to a discord limitation. To combat this I added a system which calculates the invite which will expire soonest, sleeps until then and then removes it from the cache. 
  
  How it works:
  - There are two tasks, `delete_expired` and `update_invite_expiry` which are made using the `ext.tasks` extension of `discord.py`. `delete_expired` has no poll period and `update_invite_expiry` has a 29 minute poll period.
  - The two tasks are both started in the `__ainit__` asyncio task which is created in the `__init__` of the cog. 
  - The `_invites_ready` event is now set in the `update_invite_expiry` after it completes its first iteration by using this logic at the end of the task body: 
  ```py
  if self.update_invite_expiry.current_loop == 0:
            self._invites_ready.set()
  ```
  - The `delete_expired` task has a `before_task` which simply uses the `wait_for_invites` function to make sure the list of soon expiring invites is populated when it runs for the first time.
  - The `update_invite_expiry` task runs every 25 minutes, it doesn't need to update the list too often because the minimum expiry time one can set for an invite is 30 minutes. This task works by flattening all the invite objects in the cache into one list. It then assigns a variable to the current unix time `time.time()`. Then we perform dict comprehension on the flattened list mapping it like `Mapping[seconds_till_expiry, discord.Invite]`, in the dict comp any invites with a `max_age` of `0` are ignored because this means they do not expire. A bot var called `last_update` is assigned to the `current` variable after the dict comprehension and this is used in the `delete_expired` to find how long it has been since the last calculation to determine how much time the shortest invite has left. 
  - The logic in `delete_expired` is quite simple, all it does it get the `expiring_invites` dict, gets the time to sleep by using the `min` function on the keys of the dictionary and then indexes the dictionary with that to get the invite object. It then sleeps for `expiry_time - int(time.time() - self.bot.last_update)` and after removes the invite from the expiring invites list and the main cache.
  - However, with this system another problem arises. Say you have a invite that is currently being slept on in `delete_expired`, lets say there are another 6000 seconds until it will be expired and thus removed from the cache, however if during this period say a invite is created that expires in 30 minutes (1800 seconds), the system will sleep until the 6000 seconds one is expired and only then realise it has a way overdue invite. To combat this I use a conditional in `update_invite_expiry` after created the new dictionary, this checks if the current invite in `delete_expired` is longer than the one with the shortest expiry time in the new dictionary. If this is the case it will restart the `delete_expired` task so it re-fetches the shortest expiry invite and sleeps on it. This is not a problem when invites are deleted however because if the deleted invite is currently being slept on, all other invites will be longer than it anyway and it will continue to work fine. 
  
- on_guild_available

  Previously in `on_guild_available`, the guild invites were fetched from the gateway and looped through them. In each iteration of the loop the new invite is looked up in the cache. If it is in the cache it will try and detect changes by comparing the two invites with `!=` and if this conditional is `True` it will replace the cached invite with the new invite. 
  
  This system has many flaws, first of it does not support created invites or deleted invites. This is because it checks if the invite is the cache and only if it is in the cache it will take action. This means that if an invite has been created during the unavailability it will not be in the cache and thus ignored, if an invite has been deleted in the time it still will be in the cache but it won't be in the invites and will never be checked in the for loop.
  
  This is not the only flaw however. If you look into the `__eq__` and `__ne__` methods of the invites you will find that they are only compared by class and code but the purpose of the conditional is to check if the uses of the invites have changed which makes it useless. 
  
  To fix this the whole guild cache is replaced with no looping or checking anything.

- on_guild_channel_delete

  Two small changes were made in `on_guild_channel_delete`. In the event all invites which belonged to the channel were appended to a list and then this list was looped through and all the invites in the list were removed from the cache. This is unnecessary because you can just remove the invite from the cache where it is appended to the list.
  
  Another small change is that when the invite channel is compared to the channel that was deleted they compare like `channel_obj == channel_obj`. This behaviour has been changed to compare using id to adhere with this warning in the docs:
  
  ![image](https://user-images.githubusercontent.com/70792267/103739793-38762180-504a-11eb-805e-802ac7114c4a.png)

  Although this is rare, it can still happen and cause an error because of an invite not being removed from the cache.

- invitestats command

  This command has had a revamp. The command now only works in guilds and displays only invites from the guild that it is ran in. The basic idea of the command is display the ten invites with the most uses in the guild. The command uses embeds to format this. There is no error handler attached to the command so if someone wants to use it they can handle `commands.NoPrivateMessage` as they wish.


### Notes

- The code may require some formatting to make it more readable, judge this as you wish.
- Some of the logic (mainly the timer system) may of been left out in the explanation in this pull request, if you would like me to explain any of the logic and why I do certain things I will be happy to explain, I will reply to comments and you can contact me on discord `dog.#4281`. 
- Any suggestions and constructive criticism are warmly encouraged.
  
  
 
