### PR TITLE
change task behaviour

### DIFF
--- a/invites.py
+++ b/invites.py
@@ -59,6 +59,11 @@ class Invites(commands.Cog):
         self.update_invite_expiry.start()
         self.delete_expired.start()
 
+    def cog_unload(self):
+        self.update_invite_expiry.cancel()
+        if not self.delete_expired.done():
+            self.delete_expired.cancel()
+
     @tasks.loop()
     async def delete_expired(self):
         invites = self.bot.expiring_invites

--- a/invites.py
+++ b/invites.py
@@ -42,7 +42,7 @@ class Invites(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self._invites_ready = asyncio.Event()
-        self._list_filled = asyncio.Event()
+        self._dict_filled = asyncio.Event()
 
         self.bot.invites = {}
         self.bot.get_invite = self.get_invite
@@ -61,42 +61,25 @@ class Invites(commands.Cog):
 
     def cog_unload(self):
         self.update_invite_expiry.cancel()
-        if not self.delete_expired.done():
-            self.delete_expired.cancel()
+        self.delete_expired.cancel()
 
     @tasks.loop()
     async def delete_expired(self):
+        if not self.bot.expiring_invites:
+            await self._dict_filled.wait()
         invites = self.bot.expiring_invites
-        if not invites:
-            # get the internal task
-            task = self.delete_expired.get_task()
-
-            def restart_when_list_filled(fut):
-                task.remove_done_callback(restart_when_list_filled)
-
-                async def wait():
-                    await self._list_filled.wait()
-                    self.delete_expired.start()
-
-                self.bot.loop.create_task(wait())
-
-            # don't want to try and cancel the task if we
-            # are already cancelling so we check that
-            # the task is not already being cancelled
-            if not self.delete_expired.is_being_cancelled():
-                task.add_done_callback(restart_when_list_filled)
-                self.delete_expired.cancel()
-        # if the list is populated
-        else:
-            expiry_time = min(invites.keys())
-            inv = invites[expiry_time]
-            sleep_time = expiry_time - (int(time.time()) - self.bot.last_update)
-            self.bot.shortest_invite = expiry_time
-            await asyncio.sleep(sleep_time)
-            # delete invite from cache
-            self.delete_invite(inv)
-            # delete invite from expiring invite list
-            self.bot.expiring_invites.pop(expiry_time, None)
+        expiry_time = min(invites.keys())
+        inv = invites[expiry_time]
+        sleep_time = expiry_time - (int(time.time()) - self.bot.last_update)
+        self.bot.shortest_invite = expiry_time
+        await asyncio.sleep(sleep_time)
+        # delete invite from cache
+        self.delete_invite(inv)
+        # delete invite from expiring invite list
+        # bot.shortest_invite is updated in update_invite_expiry
+        # and since the expiring_invites dict is also updated
+        # so the time goes down we use this instead
+        self.bot.expiring_invites.pop(self.bot.shortest_invite, None)
 
     @delete_expired.before_loop
     async def wait_for_list(self):
@@ -104,11 +87,6 @@ class Invites(commands.Cog):
 
     @tasks.loop(minutes=POLL_PERIOD)
     async def update_invite_expiry(self):
-        # check to see if it is set
-        # because on the first iteration
-        # it will not be
-        if self._list_filled.is_set():
-            self._list_filled.clear()
         # flatten all the invites in the cache into one single list
         flattened = [invite for inner in self.bot.invites.values() for invite in inner.values()]
         # get current posix time
@@ -152,7 +130,8 @@ class Invites(commands.Cog):
         # set the event so if the delete_expired
         # task is cancelled it will start again
         if self.bot.expiring_invites:
-            self._list_filled.set()
+            self._dict_filled.set()
+            self._dict_filled.clear()
 
     def delete_invite(self, invite: discord.Invite) -> None:
         entry_found = self.get_invites(invite.guild.id)


### PR DESCRIPTION
Just a small change because of something I overlooked when I made #2 

In the `delete_expired` task I cancel it if the `expiring_invites` list is empty because its useless to be running. It cancels until the list gets populated again. To do this I accessed two protected members of the task, `_task` and `_can_be_cancelled`. I was not happy with this at all so after overlooking the situation I found this could be done without accessing any protected members.

~~First of all, a really blatant mistake is that I missed a function when I was reading the docs for `ext.tasks`. That function was `get_task` which gives you the task which means that part is sorted. As for `_can_be_cancelled`, after looking at the source all this function does is check if `_task` is truthy, `not _task.done()` and `not is_being_cancelled` the first too are taken care off already because we do this inside of the task so it must exist and it isn't done, `is_being_cancelled` is documented and it isn't a protected member which means with these solutions we can achieve the same thing without accessing any protected members.~~

There are also ~~three~~ two other small changes:
- There has been a conditional added to `update_invite_expiry` to check that there are invites in `expiry_invites` before setting `_list_filled`.

~~- I have also saw that a `cog_unload` has been added and have added a conditional to make sure that the `delete_expired` task is running before cancelling it.~~

- I know use `bot.shortest_invite` to pop the slept on invite of the dictionary because the dictionary may change while the task is sleeping.

~~**Note:** If you were not in the task that you wanted to cancel you can still make the same check because `.done()` is not a protected method and you can get the task with `get_task`.~~

OKAY OKAY SO

I overthought this the first and second time around, there is a much easier way to do this.
Simply wait for the dict to be filled at the start of the task if it isn't already.

Thank you for listening to my ted talk.

ps. the changes that aren't crossed out actually are the ones that have been changed

also i think before the cancelling didn't work properly and it may of been running the `if not invites` code many times in succession without good reason